### PR TITLE
Port ZMQ REQ-REP loop to v2 RemoteControl protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,18 @@ Laser ablation rastering control: Thorlabs Z912 motors, IDS uEye camera, pattern
 
 ## BLACS Integration
 
-This GUI is integrated into the BLACS experiment control system (labscript-suite). The ZMQ server in `raster_controller.py:_zmq_loop()` speaks the RemoteControl JSON protocol.
+This GUI is integrated into the BLACS experiment control system (labscript-suite). The ZMQ server in `raster_controller.py:_zmq_loop()` speaks the **v2 RemoteControl protocol** (2026-05-23 cutover).
+
+Module-level `_RasteringV2Server(RemoteControlServerBase)` (imported from parent's `userlib/external_gui_lib/zmq_v2.py`) handles REQ-REP dispatch via `@handler`-decorated methods. PUB-SUB stays raw `zmq.PUB` (topics already match spec §4.1 `{conn}_monitor`). Special cases:
+
+- `move_to_next` iterator-end was non-spec v1 `"FINISHED"`; now SUCCESS + `extra.finished=True` (spec §1.3 fixes 5-token enum). BLACS-side `RasteringWorker.transition_to_buffered` checks `response.get("finished") is True`.
+- `arm_raster` returns SUCCESS + `extra.mode={"continuous","step"}`.
+- `timeout_sec` lives in v2 `args` dict (Q2). Defaults to 10s.
 
 - **BLACS device code**: `C:\Users\radmo\labscript-suite\userlib\user_devices\RasteringDevice\`
 - **Full integration docs**: see `BLACS_Integration_Notes.md` in that directory
-- **BLACS communication protocol**: read `C:\Users\radmo\labscript-suite\userlib\user_devices\BLACS_COMMUNICATION_CONTRACT.md`
+- **Canonical v2 protocol spec**: `C:\Users\radmo\labscript-suite\docs\remotecontrol-zmq-protocol-v2.md`
+- **DEPRECATED v1 contract**: `C:\Users\radmo\labscript-suite\userlib\user_devices\BLACS_COMMUNICATION_CONTRACT.md` (archaeological only; v2 servers refuse v1 envelopes per Q4 hard sunset)
 - **BLACS agent**: `amo-expert` in `C:\Users\radmo\labscript-suite\.claude\agents\`
 
 **If changing ZMQ connection names or PUB-SUB topics**, the BLACS device must also be updated. See the BLACS Integration section in the `ablation-tech` agent prompt for the full list of shared connection names.

--- a/raster_controller.py
+++ b/raster_controller.py
@@ -338,6 +338,13 @@ class _RasteringV2Server(RemoteControlServerBase):
         except (TypeError, ValueError):
             return default
 
+    def _unknown_connection(self, *, request_id, connection):
+        return self._err(
+            request_id=request_id, status="UNKNOWN_CONNECTION",
+            code="unknown_connection",
+            message=f"unknown_connection: {connection}",
+        )
+
     # ---- PROGRAM_VALUE ----
     @handler("PROGRAM_VALUE")
     def _handle_program(self, connection, value, args, request_id):
@@ -357,7 +364,7 @@ class _RasteringV2Server(RemoteControlServerBase):
             res = mover(v, source="zmq", wait=True, timeout_s=timeout_sec)
             if res and res.ok:
                 return encode_reply(status="SUCCESS", request_id=request_id)
-            msg = res.message if res else "motor move failed"
+            msg = res.message if (res and res.message) else "motor move failed"
             return self._err(
                 request_id=request_id, code="motor_move_failed",
                 message=msg, retryable=True,
@@ -377,14 +384,14 @@ class _RasteringV2Server(RemoteControlServerBase):
 
             # Review I-2 2026-05-23: validate AND commit in a single
             # critical section. The prior shape dropped the lock
-            # between the has_iter+active read and the
+            # between the has-path+active read and the
             # _raster_continuous write -- another thread (GUI cancel,
-            # raster_finished_signal) could null _raster_iter or clear
+            # raster_finished_signal) could clear _raster_path_pts or
             # _raster_active in the gap, then we'd write
             # _raster_continuous on a torn-down raster. Consolidating
             # validate+commit closes that window.
             with self._outer._state_lock:
-                if (self._outer._raster_iter is None
+                if (not self._outer._raster_path_pts
                         or not self._outer._raster_active):
                     return self._err(
                         request_id=request_id, code="no_raster_configured",
@@ -438,11 +445,8 @@ class _RasteringV2Server(RemoteControlServerBase):
                 message=res.message,
             )
 
-        return self._err(
-            request_id=request_id, status="UNKNOWN_CONNECTION",
-            code="unknown_connection",
-            message=f"unknown_connection: {connection}",
-        )
+        return self._unknown_connection(
+            request_id=request_id, connection=connection)
 
     # ---- CHECK_VALUE ----
     @handler("CHECK_VALUE")
@@ -455,11 +459,8 @@ class _RasteringV2Server(RemoteControlServerBase):
         elif connection in self._MONITOR_Y:
             v = txy[1] if txy is not None else (mxy[1] if mxy is not None else None)
         else:
-            return self._err(
-                request_id=request_id, status="UNKNOWN_CONNECTION",
-                code="unknown_connection",
-                message=f"unknown_connection: {connection}",
-            )
+            return self._unknown_connection(
+                request_id=request_id, connection=connection)
         return encode_reply(status="SUCCESS", request_id=request_id, value=v)
 
 
@@ -1975,15 +1976,28 @@ class SystemController(QObject):
             pub_sock.bind(pub_bind)
 
         pub_counter = 0
+        pub_send_failed = False
 
         def publish(topic: str, value: str = "") -> None:
+            nonlocal pub_send_failed
             if pub_sock is not None:
                 msg = f"{topic} {value}" if value else topic
                 try:
                     pub_sock.send_string(msg)
-                except Exception:
-                    pass  # socket closed or errored; don't kill the ZMQ loop
+                    pub_send_failed = False
+                except Exception as e:
+                    # Don't kill the ZMQ loop on a broken PUB socket, but
+                    # surface the first failure of a burst -- to stderr and
+                    # the GUI -- instead of silently dropping every monitor
+                    # update (which leaves the BLACS dashboard stale with no
+                    # clue why). The flag re-arms after a successful send.
+                    if not pub_send_failed:
+                        pub_send_failed = True
+                        print(f"[raster zmq] PUB send failed: {e!r}")
+                        self.error_signal.emit(
+                            f"ZMQ status broadcast failed: {e}")
 
+        consecutive_serve_failures = 0
         while not self._zmq_stop_evt.is_set():
             # --- PUB-SUB broadcasting (runs at loop rate, ~4 Hz) ---
             if pub_sock is not None:
@@ -2024,16 +2038,30 @@ class SystemController(QObject):
             # --- REQ-REP via v2 base class ---
             try:
                 v2_server.serve_once(timeout_ms=250)
+                consecutive_serve_failures = 0
             except Exception:
                 # Base catches handler exceptions and returns ERROR
                 # replies; any exception reaching here is transport-level.
                 # Review I-3 2026-05-23: do NOT swallow silently --
                 # print traceback so a sick transport doesn't disappear
                 # into the void. We still retry on next iter rather than
-                # break (matches the BigSky port's tolerance pattern;
-                # could add a consecutive-failure circuit-breaker later).
+                # break (matches the BigSky port's tolerance pattern).
                 import traceback
                 traceback.print_exc()
+                # serve_once normally blocks up to timeout_ms; a transport
+                # that raises *immediately* would hot-spin this loop and
+                # flood stderr. Back off once failures pile up, using the
+                # stop event so a shutdown still interrupts promptly.
+                consecutive_serve_failures += 1
+                if consecutive_serve_failures == 3:
+                    # Notify the operator once on entering a sustained-
+                    # failure state -- the counter stays >=3 until a
+                    # serve_once succeeds and resets it, so this fires once
+                    # per outage, not every iteration.
+                    self.error_signal.emit(
+                        "ZMQ command transport is failing; see console for details.")
+                if consecutive_serve_failures >= 3:
+                    self._zmq_stop_evt.wait(0.25)
 
         try:
             transport.close()

--- a/raster_controller.py
+++ b/raster_controller.py
@@ -17,6 +17,7 @@ import itertools
 import json
 import os
 import queue
+import sys
 import threading
 import time
 import uuid
@@ -29,6 +30,19 @@ import zmq
 from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot, QTimer
 
 from raster_paths import collect_points
+
+# zmq_v2 protocol foundation lives in the parent labscript-suite repo.
+# This GUI runs in conda env `rastering`; inject the path.
+_EXTERNAL_LIB = os.path.normpath(os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    '..', '..', 'userlib', 'external_gui_lib',
+))
+if _EXTERNAL_LIB not in sys.path:
+    sys.path.insert(0, _EXTERNAL_LIB)
+from zmq_v2 import (
+    RemoteControlServerBase, handler, encode_reply,
+    PROTOCOL_VERSION, ZmqRepTransport,
+)
 
 
 # -----------------------------
@@ -276,6 +290,165 @@ class CalibrationSession:
 
         cal = AffineCalibration(M=M, b=off)  # may raise if singular
         return cal, diag
+
+
+# -----------------------------
+# v2 protocol dispatcher (composed inside SystemController._zmq_loop)
+# -----------------------------
+
+
+class _RasteringV2Server(RemoteControlServerBase):
+    """v2 RemoteControl dispatcher for the rastering SystemController.
+
+    Composed inside ``_zmq_loop`` (daemon thread). Holds a back-ref to
+    the outer ``SystemController`` to invoke ``request_move_*`` /
+    ``raster_step`` / state reads.
+
+    Single-instance server: no ``connections`` advertisement. Special
+    rastering replies that don't fit a single ``status`` enum:
+
+      * ``arm_raster``: returns SUCCESS + ``extra={"mode": ...}``
+      * ``move_to_next`` after iterator end: returns SUCCESS +
+        ``extra={"finished": True}`` (was v1 ``"FINISHED"``, which is
+        not in spec section 1.3's 5-token enum).
+    """
+
+    CAPABILITIES = frozenset({"monitors", "heartbeat"})
+
+    # Connections this server can program (writable) or check (monitor).
+    _WRITABLE_COORDS = ("laser_raster_x_coord", "laser_raster_y_coord")
+    _MONITOR_X = ("laser_raster_x_coord_monitor", "laser_raster_x_coord")
+    _MONITOR_Y = ("laser_raster_y_coord_monitor", "laser_raster_y_coord")
+    _SPECIAL_PROGRAM = ("arm_raster", "move_to_next")
+
+    def __init__(self, outer, transport):
+        super().__init__("RasteringGUI", transport)
+        self._outer = outer
+
+    # ---- helpers ----
+    def _err(self, *, request_id, code, message, retryable=False, status="ERROR"):
+        return encode_reply(
+            status=status, request_id=request_id,
+            error={"code": code, "message": message, "retryable": retryable},
+        )
+
+    def _timeout_from_args(self, args, default=10.0):
+        try:
+            return float(args.get("timeout_sec", default))
+        except (TypeError, ValueError):
+            return default
+
+    # ---- PROGRAM_VALUE ----
+    @handler("PROGRAM_VALUE")
+    def _handle_program(self, connection, value, args, request_id):
+        timeout_sec = self._timeout_from_args(args)
+
+        if connection in self._WRITABLE_COORDS:
+            try:
+                v = float(value)
+            except (TypeError, ValueError):
+                return self._err(
+                    request_id=request_id, code="invalid_value",
+                    message=f"value must be a number; got {value!r}",
+                )
+            mover = (self._outer.request_move_x
+                     if connection == "laser_raster_x_coord"
+                     else self._outer.request_move_y)
+            res = mover(v, source="zmq", wait=True, timeout_s=timeout_sec)
+            if res and res.ok:
+                return encode_reply(status="SUCCESS", request_id=request_id)
+            msg = res.message if res else "motor move failed"
+            return self._err(
+                request_id=request_id, code="motor_move_failed",
+                message=msg, retryable=True,
+            )
+
+        if connection == "arm_raster":
+            with self._outer._state_lock:
+                has_iter = self._outer._raster_iter is not None
+                active = self._outer._raster_active
+            if not has_iter or not active:
+                return self._err(
+                    request_id=request_id, code="no_raster_configured",
+                    message="no raster configured",
+                )
+
+            want_continuous = False
+            try:
+                if isinstance(value, str):
+                    want_continuous = value.strip().lower() in (
+                        "1", "true", "continuous", "cont")
+                else:
+                    want_continuous = bool(value)
+            except Exception:
+                want_continuous = False
+
+            with self._outer._state_lock:
+                self._outer._raster_continuous = bool(want_continuous)
+
+            if want_continuous:
+                self._outer.status_signal.emit("ZMQ: raster armed (continuous).")
+                self._outer._enqueue_next_raster_point()
+            else:
+                self._outer.status_signal.emit("ZMQ: raster armed (step mode).")
+
+            return encode_reply(
+                status="SUCCESS", request_id=request_id,
+                extra={"mode": "continuous" if want_continuous else "step"},
+            )
+
+        if connection == "move_to_next":
+            with self._outer._state_lock:
+                active = self._outer._raster_active
+                continuous = self._outer._raster_continuous
+            if not active:
+                return self._err(
+                    request_id=request_id, code="raster_not_active",
+                    message="raster not active",
+                )
+            if continuous:
+                return self._err(
+                    request_id=request_id, code="raster_in_continuous_mode",
+                    message="raster in continuous mode",
+                )
+            res = self._outer.raster_step(
+                source="zmq", wait=True, timeout_s=timeout_sec)
+            # Iterator end -> SUCCESS + finished=True (not a status enum).
+            if res is None:
+                return encode_reply(
+                    status="SUCCESS", request_id=request_id,
+                    extra={"finished": True},
+                )
+            if res.ok:
+                return encode_reply(status="SUCCESS", request_id=request_id)
+            return self._err(
+                request_id=request_id, code="raster_step_failed",
+                message=res.message,
+            )
+
+        return self._err(
+            request_id=request_id, status="UNKNOWN_CONNECTION",
+            code="unknown_connection",
+            message=f"unknown_connection: {connection}",
+        )
+
+    # ---- CHECK_VALUE ----
+    @handler("CHECK_VALUE")
+    def _handle_check(self, connection, value, args, request_id):
+        with self._outer._state_lock:
+            txy = self._outer._last_target_xy
+            mxy = self._outer._last_motor_xy
+        if connection in self._MONITOR_X:
+            v = txy[0] if txy is not None else (mxy[0] if mxy is not None else None)
+        elif connection in self._MONITOR_Y:
+            v = txy[1] if txy is not None else (mxy[1] if mxy is not None else None)
+        else:
+            return self._err(
+                request_id=request_id, status="UNKNOWN_CONNECTION",
+                code="unknown_connection",
+                message=f"unknown_connection: {connection}",
+            )
+        return encode_reply(status="SUCCESS", request_id=request_id, value=v)
 
 
 # -----------------------------
@@ -1766,28 +1939,30 @@ class SystemController(QObject):
     # -------------------------
 
     def _zmq_loop(self, bind: str, pub_bind: str = "") -> None:
-        """
-        Compatibility server with your existing JSON protocol:
-        - action: PROGRAM_VALUE / CHECK_VALUE
-        - connection names: laser_raster_x_coord, laser_raster_y_coord, monitors, arm_raster, disarm_raster, move_to_next
+        """v2 protocol REP loop + raw PUB broadcasting.
 
-        Also runs a PUB socket for broadcasting status to BLACS (if pub_bind is set).
+        REP-side: ``_RasteringV2Server`` (RemoteControlServerBase
+        subclass at module top) handles parse/dispatch/encode via
+        @handler-decorated methods on ``SystemController``-facing
+        operations.
+
+        PUB-side: raw zmq.PUB socket, unchanged from v1 (topic format
+        already matches spec section 4.1: ``{conn}_monitor`` for the
+        XY position monitors; ``heartbeat`` / ``raster_mode`` /
+        ``calibration_status`` / ``raster_progress`` retained as
+        legacy non-spec topics consumed by the BLACS tab subscriber).
         """
-        ctx = zmq.Context.instance()
-        sock = ctx.socket(zmq.REP)
-        sock.bind(bind)
-        sock.RCVTIMEO = 250  # ms, so we can exit cleanly
+        transport = ZmqRepTransport(bind, recv_timeout_ms=250)
+        v2_server = _RasteringV2Server(self, transport)
 
         # PUB socket for status broadcasting to BLACS
         pub_sock = None
         if pub_bind:
+            ctx = zmq.Context.instance()
             pub_sock = ctx.socket(zmq.PUB)
             pub_sock.bind(pub_bind)
 
         pub_counter = 0
-
-        def reply(obj: Dict[str, Any]) -> None:
-            sock.send(json.dumps(obj).encode())
 
         def publish(topic: str, value: str = "") -> None:
             if pub_sock is not None:
@@ -1834,128 +2009,17 @@ class SystemController(QObject):
 
                     publish("raster_progress", f"{step_count}/{total_steps}")
 
-            # --- REQ-REP handling ---
+            # --- REQ-REP via v2 base class ---
             try:
-                req = sock.recv()
-            except zmq.error.Again:
-                continue
-            except Exception as e:
-                # socket error; bail
-                break
-
-            try:
-                data = json.loads(req.decode())
-                action = data.get("action", "")
-                connection = data.get("connection", "")
-                value = data.get("value", None)
+                v2_server.serve_once(timeout_ms=250)
             except Exception:
-                reply({"status": "ERROR", "message": "bad_json"})
-                continue
-
-            # HELLO: connection check from BLACS
-            if action == "HELLO":
-                reply({"status": "SUCCESS"})
-                continue
-
-            # CHECK_VALUE: return cached target coords (preferred) else motor coords
-            if action == "CHECK_VALUE":
-                with self._state_lock:
-                    txy = self._last_target_xy
-                    mxy = self._last_motor_xy
-                if connection in ("laser_raster_x_coord_monitor", "laser_raster_x_coord"):
-                    v = txy[0] if txy is not None else (mxy[0] if mxy is not None else None)
-                elif connection in ("laser_raster_y_coord_monitor", "laser_raster_y_coord"):
-                    v = txy[1] if txy is not None else (mxy[1] if mxy is not None else None)
-                else:
-                    reply({"status": "ERROR", "message": f"unknown_connection: {connection}"})
-                    continue
-                reply({"status": "SUCCESS", "value": v})
-                continue
-
-            if action != "PROGRAM_VALUE":
-                reply({"status": "ERROR", "message": "unknown_action"})
-                continue
-
-            # PROGRAM_VALUE
-            try:
-                timeout_sec = float(data.get("timeout_sec", 10.0))
-            except Exception:
-                timeout_sec = 10.0
-
-            if connection == "laser_raster_x_coord":
-                res = self.request_move_x(float(value), source="zmq", wait=True, timeout_s=timeout_sec)
-                reply({"status": "SUCCESS" if res and res.ok else "ERROR", "message": (res.message if res else "")})
-                continue
-
-            if connection == "laser_raster_y_coord":
-                res = self.request_move_y(float(value), source="zmq", wait=True, timeout_s=timeout_sec)
-                reply({"status": "SUCCESS" if res and res.ok else "ERROR", "message": (res.message if res else "")})
-                continue
-
-            if connection == "arm_raster":
-                # Allow caller to choose mode:
-                # - value truthy => continuous
-                # - value falsy/None => step mode
-                with self._state_lock:
-                    has_path = bool(self._raster_path_pts)
-                    active = self._raster_active
-
-                if not has_path or not active:
-                    reply({"status": "ERROR", "message": "no_raster_configured"})
-                    continue
-
-                want_continuous = False
-                try:
-                    # Accept: 1, True, "1", "true", "continuous"
-                    if isinstance(value, str):
-                        want_continuous = value.strip().lower() in ("1", "true", "continuous", "cont")
-                    else:
-                        want_continuous = bool(value)
-                except Exception:
-                    want_continuous = False
-
-                with self._state_lock:
-                    self._raster_continuous = bool(want_continuous)
-
-                if want_continuous:
-                    self.status_signal.emit("ZMQ: raster armed (continuous).")
-                    self._enqueue_next_raster_point()
-                else:
-                    self.status_signal.emit("ZMQ: raster armed (step mode).")
-
-                reply({"status": "SUCCESS", "mode": ("continuous" if want_continuous else "step")})
-                continue
-
-
-            if connection == "move_to_next":
-                # Step-mode handshake: move exactly one step, then reply when done.
-                with self._state_lock:
-                    active = self._raster_active
-                    continuous = self._raster_continuous
-
-                if not active:
-                    reply({"status": "ERROR", "message": "raster_not_active"})
-                    continue
-
-                if continuous:
-                    reply({"status": "ERROR", "message": "raster_in_continuous_mode"})
-                    continue
-
-                res = self.raster_step(source="zmq", wait=True, timeout_s=timeout_sec)
-
-                # If iterator ended, raster_step() returns None and _finish_raster() fires signals.
-                if res is None:
-                    reply({"status": "FINISHED"})
-                else:
-                    reply({"status": "SUCCESS" if res.ok else "ERROR", "message": res.message})
-                continue
-
-            # Fallthrough: unrecognized connection for PROGRAM_VALUE
-            reply({"status": "ERROR", "message": f"unknown_connection: {connection}"})
-            continue
+                # Base catches handler exceptions and returns ERROR replies;
+                # a true transport error would have come from recv -- in
+                # which case retry on next iter.
+                pass
 
         try:
-            sock.close(0)
+            transport.close()
         except Exception:
             pass
         if pub_sock is not None:

--- a/raster_controller.py
+++ b/raster_controller.py
@@ -364,15 +364,7 @@ class _RasteringV2Server(RemoteControlServerBase):
             )
 
         if connection == "arm_raster":
-            with self._outer._state_lock:
-                has_iter = self._outer._raster_iter is not None
-                active = self._outer._raster_active
-            if not has_iter or not active:
-                return self._err(
-                    request_id=request_id, code="no_raster_configured",
-                    message="no raster configured",
-                )
-
+            # Parse `value` outside the lock (no shared state read).
             want_continuous = False
             try:
                 if isinstance(value, str):
@@ -383,9 +375,29 @@ class _RasteringV2Server(RemoteControlServerBase):
             except Exception:
                 want_continuous = False
 
+            # Review I-2 2026-05-23: validate AND commit in a single
+            # critical section. The prior shape dropped the lock
+            # between the has_iter+active read and the
+            # _raster_continuous write -- another thread (GUI cancel,
+            # raster_finished_signal) could null _raster_iter or clear
+            # _raster_active in the gap, then we'd write
+            # _raster_continuous on a torn-down raster. Consolidating
+            # validate+commit closes that window.
             with self._outer._state_lock:
+                if (self._outer._raster_iter is None
+                        or not self._outer._raster_active):
+                    return self._err(
+                        request_id=request_id, code="no_raster_configured",
+                        message="no raster configured",
+                    )
                 self._outer._raster_continuous = bool(want_continuous)
 
+            # status_signal.emit + _enqueue_next_raster_point are
+            # intentionally OUTSIDE the lock (Qt emit is cross-thread;
+            # _enqueue may take other locks). A late raster_cancel
+            # between here and _enqueue_next_raster_point will be
+            # handled by the controller's own active-check inside the
+            # enqueue path.
             if want_continuous:
                 self._outer.status_signal.emit("ZMQ: raster armed (continuous).")
                 self._outer._enqueue_next_raster_point()
@@ -2013,10 +2025,15 @@ class SystemController(QObject):
             try:
                 v2_server.serve_once(timeout_ms=250)
             except Exception:
-                # Base catches handler exceptions and returns ERROR replies;
-                # a true transport error would have come from recv -- in
-                # which case retry on next iter.
-                pass
+                # Base catches handler exceptions and returns ERROR
+                # replies; any exception reaching here is transport-level.
+                # Review I-3 2026-05-23: do NOT swallow silently --
+                # print traceback so a sick transport doesn't disappear
+                # into the void. We still retry on next iter rather than
+                # break (matches the BigSky port's tolerance pattern;
+                # could add a consecutive-failure circuit-breaker later).
+                import traceback
+                traceback.print_exc()
 
         try:
             transport.close()

--- a/tests/test_zmq_v2_protocol.py
+++ b/tests/test_zmq_v2_protocol.py
@@ -58,7 +58,7 @@ def zmq_v2():
 
 
 def _make_outer(*, target_xy=None, motor_xy=None,
-                raster_active=False, raster_iter=False,
+                raster_active=False, raster_has_path=False,
                 raster_continuous=False, move_x_ok=True, move_y_ok=True,
                 step_returns=None, raster_step_calls=None):
     """Stand-in for SystemController; duck-typed to what _RasteringV2Server
@@ -70,7 +70,9 @@ def _make_outer(*, target_xy=None, motor_xy=None,
     outer._last_motor_xy = motor_xy
     outer._raster_active = raster_active
     outer._raster_continuous = raster_continuous
-    outer._raster_iter = object() if raster_iter else None
+    # Real controller uses an indexed point list (_raster_path_pts), not a
+    # one-shot generator; a non-empty list means "raster configured".
+    outer._raster_path_pts = [(0.0, 0.0)] if raster_has_path else []
 
     def _move_ok(value, *, source, wait, timeout_s):
         res = mock.MagicMock()
@@ -171,7 +173,7 @@ def test_v2_program_value_timeout_sec_moves_into_args(make_v2_pair):
 
 
 def test_v2_program_value_arm_raster_continuous_returns_extra_mode(make_v2_pair):
-    outer, client_t, v2_server = make_v2_pair(raster_active=True, raster_iter=True)
+    outer, client_t, v2_server = make_v2_pair(raster_active=True, raster_has_path=True)
     reply = _roundtrip(client_t, v2_server, {
         "v": 2, "id": 10, "action": "PROGRAM_VALUE",
         "connection": "arm_raster", "value": 1,
@@ -182,7 +184,7 @@ def test_v2_program_value_arm_raster_continuous_returns_extra_mode(make_v2_pair)
 
 
 def test_v2_program_value_arm_raster_step_mode(make_v2_pair):
-    outer, client_t, v2_server = make_v2_pair(raster_active=True, raster_iter=True)
+    outer, client_t, v2_server = make_v2_pair(raster_active=True, raster_has_path=True)
     reply = _roundtrip(client_t, v2_server, {
         "v": 2, "id": 11, "action": "PROGRAM_VALUE",
         "connection": "arm_raster", "value": 0,
@@ -193,7 +195,7 @@ def test_v2_program_value_arm_raster_step_mode(make_v2_pair):
 
 
 def test_v2_program_value_arm_raster_without_config_rejected(make_v2_pair):
-    outer, client_t, v2_server = make_v2_pair(raster_active=False, raster_iter=False)
+    outer, client_t, v2_server = make_v2_pair(raster_active=False, raster_has_path=False)
     reply = _roundtrip(client_t, v2_server, {
         "v": 2, "id": 12, "action": "PROGRAM_VALUE",
         "connection": "arm_raster", "value": 1,
@@ -240,6 +242,42 @@ def test_v2_program_value_move_to_next_continuous_mode_rejected(make_v2_pair):
     })
     assert reply["status"] == "ERROR"
     assert reply["error"]["code"] == "raster_in_continuous_mode"
+
+
+def test_v2_program_value_move_to_next_not_active_rejected(make_v2_pair):
+    outer, client_t, v2_server = make_v2_pair(raster_active=False)
+    reply = _roundtrip(client_t, v2_server, {
+        "v": 2, "id": 20, "action": "PROGRAM_VALUE",
+        "connection": "move_to_next", "value": None,
+    })
+    assert reply["status"] == "ERROR"
+    assert reply["error"]["code"] == "raster_not_active"
+
+
+def test_v2_program_value_move_to_next_step_failed(make_v2_pair):
+    res_mock = mock.MagicMock(ok=False, message="motor stalled")
+    outer, client_t, v2_server = make_v2_pair(
+        raster_active=True, raster_continuous=False,
+        step_returns=lambda **kw: res_mock,
+    )
+    reply = _roundtrip(client_t, v2_server, {
+        "v": 2, "id": 21, "action": "PROGRAM_VALUE",
+        "connection": "move_to_next", "value": None,
+    })
+    assert reply["status"] == "ERROR"
+    assert reply["error"]["code"] == "raster_step_failed"
+    assert reply["error"]["message"] == "motor stalled"
+
+
+def test_v2_program_value_non_numeric_coord_rejected(make_v2_pair):
+    outer, client_t, v2_server = make_v2_pair()
+    reply = _roundtrip(client_t, v2_server, {
+        "v": 2, "id": 22, "action": "PROGRAM_VALUE",
+        "connection": "laser_raster_x_coord", "value": "not-a-number",
+    })
+    assert reply["status"] == "ERROR"
+    assert reply["error"]["code"] == "invalid_value"
+    outer.request_move_x.assert_not_called()
 
 
 def test_v2_program_value_unknown_connection(make_v2_pair):

--- a/tests/test_zmq_v2_protocol.py
+++ b/tests/test_zmq_v2_protocol.py
@@ -1,0 +1,283 @@
+"""Rastering ZMQ v2 protocol roundtrip via InMemoryTransport.
+
+Exercises the REAL ``_RasteringV2Server`` (RemoteControlServerBase
+subclass) in ``raster_controller.py``. No sockets bound; tests pair
+two ``InMemoryTransport`` instances so the dispatcher path runs
+end-to-end with real envelope encode/parse.
+
+Pins:
+  * HELLO reply: status SUCCESS, protocol_version 2,
+    capabilities = {monitors, heartbeat}, NO ``connections`` key.
+  * v1 hard sunset: missing ``v`` -> v1_protocol_refused.
+  * id echo on every reply.
+  * PROGRAM_VALUE for coord channels delegates to request_move_x/y.
+  * PROGRAM_VALUE arm_raster returns SUCCESS + extra.mode.
+  * PROGRAM_VALUE move_to_next end-of-iter -> SUCCESS + extra.finished.
+  * CHECK_VALUE returns cached target XY when present, else motor XY.
+  * timeout_sec moves into args dict (Q2 §10-resolved).
+
+Run:
+    conda activate rastering && pytest tests/test_zmq_v2_protocol.py -v
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+from unittest import mock
+
+import pytest
+
+# raster_controller.py lives one level up from tests/.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+try:
+    import raster_controller as rc  # noqa: E402
+    _IMPORT_ERR = None
+except Exception as e:  # noqa: BLE001
+    rc = None  # type: ignore
+    _IMPORT_ERR = e
+
+
+def _require_rc():
+    if _IMPORT_ERR is not None:
+        pytest.skip(
+            "raster_controller not importable (rastering env?): " + repr(_IMPORT_ERR))
+
+
+# ---------------------------------------------------------------- fixtures
+
+
+@pytest.fixture(scope="module")
+def zmq_v2():
+    _require_rc()
+    pytest.importorskip("zmq_v2")
+    import zmq_v2  # noqa: PLC0415
+    return zmq_v2
+
+
+def _make_outer(*, target_xy=None, motor_xy=None,
+                raster_active=False, raster_iter=False,
+                raster_continuous=False, move_x_ok=True, move_y_ok=True,
+                step_returns=None, raster_step_calls=None):
+    """Stand-in for SystemController; duck-typed to what _RasteringV2Server
+    actually reads/calls."""
+    _require_rc()
+    outer = mock.MagicMock()
+    outer._state_lock = threading.RLock()
+    outer._last_target_xy = target_xy
+    outer._last_motor_xy = motor_xy
+    outer._raster_active = raster_active
+    outer._raster_continuous = raster_continuous
+    outer._raster_iter = object() if raster_iter else None
+
+    def _move_ok(value, *, source, wait, timeout_s):
+        res = mock.MagicMock()
+        res.ok = bool(value)  # value=0 -> fail; non-zero -> ok per test seed
+        res.message = "" if res.ok else "rejected"
+        return res
+
+    def _make_move_factory(success):
+        def _move(value, *, source, wait, timeout_s):
+            res = mock.MagicMock()
+            res.ok = success
+            res.message = "" if success else "motor rejected"
+            return res
+        return _move
+
+    outer.request_move_x.side_effect = _make_move_factory(move_x_ok)
+    outer.request_move_y.side_effect = _make_move_factory(move_y_ok)
+    outer.raster_step.side_effect = (
+        step_returns if step_returns is not None
+        else (lambda **kw: (mock.MagicMock(ok=True, message=""))))
+    return outer
+
+
+def _roundtrip(client_t, v2_server, envelope_dict):
+    client_t.send(json.dumps(envelope_dict).encode("utf-8"))
+    served = v2_server.serve_once(timeout_ms=100)
+    assert served is True
+    return json.loads(client_t.recv(timeout_ms=100).decode("utf-8"))
+
+
+@pytest.fixture
+def make_v2_pair(zmq_v2):
+    def _factory(**kwargs):
+        outer = _make_outer(**kwargs)
+        client_t, server_t = zmq_v2.InMemoryTransport.pair()
+        v2_server = rc._RasteringV2Server(outer, server_t)
+        return outer, client_t, v2_server
+    return _factory
+
+
+# ---------------------------------------------------------------- tests
+
+
+def test_v2_hello_single_instance_no_connections_key(zmq_v2, make_v2_pair):
+    outer, client_t, v2_server = make_v2_pair()
+    reply = _roundtrip(client_t, v2_server,
+                       {"v": 2, "id": 1, "action": "HELLO"})
+    assert reply["status"] == "SUCCESS"
+    assert reply["id"] == 1
+    assert reply["server"] == "RasteringGUI"
+    assert set(reply["capabilities"]) == {"monitors", "heartbeat"}
+    assert "connections" not in reply
+
+
+def test_v2_v1_envelope_refused(make_v2_pair):
+    outer, client_t, v2_server = make_v2_pair()
+    reply = _roundtrip(client_t, v2_server, {"action": "HELLO"})
+    assert reply["status"] == "ERROR"
+    assert reply["error"]["code"] == "v1_protocol_refused"
+
+
+def test_v2_program_value_x_delegates_to_request_move_x(make_v2_pair):
+    outer, client_t, v2_server = make_v2_pair(move_x_ok=True)
+    reply = _roundtrip(client_t, v2_server, {
+        "v": 2, "id": 7, "action": "PROGRAM_VALUE",
+        "connection": "laser_raster_x_coord", "value": 12.5,
+    })
+    assert reply["status"] == "SUCCESS"
+    assert reply["id"] == 7
+    outer.request_move_x.assert_called_once()
+    args, kwargs = outer.request_move_x.call_args
+    assert args[0] == 12.5
+    assert kwargs["source"] == "zmq"
+    assert kwargs["wait"] is True
+
+
+def test_v2_program_value_motor_failure_returns_retryable(make_v2_pair):
+    outer, client_t, v2_server = make_v2_pair(move_x_ok=False)
+    reply = _roundtrip(client_t, v2_server, {
+        "v": 2, "id": 8, "action": "PROGRAM_VALUE",
+        "connection": "laser_raster_x_coord", "value": 12.5,
+    })
+    assert reply["status"] == "ERROR"
+    assert reply["error"]["code"] == "motor_move_failed"
+    assert reply["error"]["retryable"] is True
+
+
+def test_v2_program_value_timeout_sec_moves_into_args(make_v2_pair):
+    """Q2 §10-resolved: per-request extras live in args, not top-level."""
+    outer, client_t, v2_server = make_v2_pair(move_x_ok=True)
+    _roundtrip(client_t, v2_server, {
+        "v": 2, "id": 9, "action": "PROGRAM_VALUE",
+        "connection": "laser_raster_x_coord", "value": 5.0,
+        "args": {"timeout_sec": 30.0},
+    })
+    _, kwargs = outer.request_move_x.call_args
+    assert kwargs["timeout_s"] == 30.0
+
+
+def test_v2_program_value_arm_raster_continuous_returns_extra_mode(make_v2_pair):
+    outer, client_t, v2_server = make_v2_pair(raster_active=True, raster_iter=True)
+    reply = _roundtrip(client_t, v2_server, {
+        "v": 2, "id": 10, "action": "PROGRAM_VALUE",
+        "connection": "arm_raster", "value": 1,
+    })
+    assert reply["status"] == "SUCCESS"
+    assert reply["mode"] == "continuous"
+    outer._enqueue_next_raster_point.assert_called_once()
+
+
+def test_v2_program_value_arm_raster_step_mode(make_v2_pair):
+    outer, client_t, v2_server = make_v2_pair(raster_active=True, raster_iter=True)
+    reply = _roundtrip(client_t, v2_server, {
+        "v": 2, "id": 11, "action": "PROGRAM_VALUE",
+        "connection": "arm_raster", "value": 0,
+    })
+    assert reply["status"] == "SUCCESS"
+    assert reply["mode"] == "step"
+    outer._enqueue_next_raster_point.assert_not_called()
+
+
+def test_v2_program_value_arm_raster_without_config_rejected(make_v2_pair):
+    outer, client_t, v2_server = make_v2_pair(raster_active=False, raster_iter=False)
+    reply = _roundtrip(client_t, v2_server, {
+        "v": 2, "id": 12, "action": "PROGRAM_VALUE",
+        "connection": "arm_raster", "value": 1,
+    })
+    assert reply["status"] == "ERROR"
+    assert reply["error"]["code"] == "no_raster_configured"
+
+
+def test_v2_program_value_move_to_next_iter_end_returns_finished_extra(make_v2_pair):
+    """Iterator exhaustion: v1 used non-spec status "FINISHED"; v2 maps to
+    SUCCESS + extra.finished=True per spec §1.3 (5-token enum is fixed)."""
+    outer, client_t, v2_server = make_v2_pair(
+        raster_active=True, raster_continuous=False,
+        step_returns=lambda **kw: None,  # iterator end
+    )
+    reply = _roundtrip(client_t, v2_server, {
+        "v": 2, "id": 13, "action": "PROGRAM_VALUE",
+        "connection": "move_to_next", "value": None,
+    })
+    assert reply["status"] == "SUCCESS"
+    assert reply["finished"] is True
+
+
+def test_v2_program_value_move_to_next_step_success(make_v2_pair):
+    res_mock = mock.MagicMock(ok=True, message="")
+    outer, client_t, v2_server = make_v2_pair(
+        raster_active=True, raster_continuous=False,
+        step_returns=lambda **kw: res_mock,
+    )
+    reply = _roundtrip(client_t, v2_server, {
+        "v": 2, "id": 14, "action": "PROGRAM_VALUE",
+        "connection": "move_to_next", "value": None,
+    })
+    assert reply["status"] == "SUCCESS"
+    assert "finished" not in reply
+
+
+def test_v2_program_value_move_to_next_continuous_mode_rejected(make_v2_pair):
+    outer, client_t, v2_server = make_v2_pair(
+        raster_active=True, raster_continuous=True)
+    reply = _roundtrip(client_t, v2_server, {
+        "v": 2, "id": 15, "action": "PROGRAM_VALUE",
+        "connection": "move_to_next", "value": None,
+    })
+    assert reply["status"] == "ERROR"
+    assert reply["error"]["code"] == "raster_in_continuous_mode"
+
+
+def test_v2_program_value_unknown_connection(make_v2_pair):
+    outer, client_t, v2_server = make_v2_pair()
+    reply = _roundtrip(client_t, v2_server, {
+        "v": 2, "id": 16, "action": "PROGRAM_VALUE",
+        "connection": "frobnicate", "value": 0,
+    })
+    assert reply["status"] == "UNKNOWN_CONNECTION"
+    assert reply["error"]["code"] == "unknown_connection"
+
+
+def test_v2_check_value_returns_target_xy_when_cached(make_v2_pair):
+    outer, client_t, v2_server = make_v2_pair(
+        target_xy=(12.5, 7.3), motor_xy=(99.0, 99.0))
+    reply = _roundtrip(client_t, v2_server, {
+        "v": 2, "id": 17, "action": "CHECK_VALUE",
+        "connection": "laser_raster_x_coord_monitor",
+    })
+    assert reply["status"] == "SUCCESS"
+    assert reply["value"] == 12.5  # target, not motor
+
+
+def test_v2_check_value_falls_back_to_motor_xy_when_no_target(make_v2_pair):
+    outer, client_t, v2_server = make_v2_pair(
+        target_xy=None, motor_xy=(99.0, 88.0))
+    reply = _roundtrip(client_t, v2_server, {
+        "v": 2, "id": 18, "action": "CHECK_VALUE",
+        "connection": "laser_raster_y_coord_monitor",
+    })
+    assert reply["status"] == "SUCCESS"
+    assert reply["value"] == 88.0
+
+
+def test_v2_check_value_unknown_connection(make_v2_pair):
+    outer, client_t, v2_server = make_v2_pair()
+    reply = _roundtrip(client_t, v2_server, {
+        "v": 2, "id": 19, "action": "CHECK_VALUE",
+        "connection": "frobnicate",
+    })
+    assert reply["status"] == "UNKNOWN_CONNECTION"


### PR DESCRIPTION
## Summary

Ports the rastering GUI's ZMQ REQ-REP server from the v1 inline-dispatch
protocol to the **v2 RemoteControl protocol**, via a module-level
`_RasteringV2Server(RemoteControlServerBase)` whose `@handler`-decorated methods
dispatch `PROGRAM_VALUE` / `CHECK_VALUE`. PUB-SUB stays raw `zmq.PUB` (topics
already match spec §4.1). Then a polish pass fixed a ship-blocker and hardened
the loop.

Rebased onto current `main`; 4 commits.

### What changed
- **v2 port** (`raster_controller.py`): `_zmq_loop` now drives `v2_server.serve_once()`; the v1 `HELLO/CHECK_VALUE/PROGRAM_VALUE` if/elif dispatch is gone (HELLO + v1-envelope refusal are handled by the base class). New `tests/test_zmq_v2_protocol.py` (mock-based, no hardware).
- **Critical fix:** the `arm_raster` guard referenced `_raster_iter`, a leftover from the generator→indexed-list refactor that no longer exists on `SystemController`. Every `arm_raster` request raised `AttributeError` → ERROR reply → **BLACS could never arm a raster over ZMQ.** The test suite masked it by stubbing `_raster_iter` on the mock. Guard now checks `not _raster_path_pts or not _raster_active`; the mock stubs the real attribute so the suite exercises the real guard.
- **Robustness:** empty motor-failure message falls back to a real string; `serve_once` gets a consecutive-failure backoff (no hot-spin); PUB-send failures are no longer silently swallowed; both transport failure paths surface to the GUI via `error_signal` (once per outage burst).
- **Coverage:** added tests for `raster_not_active`, `raster_step_failed`, `invalid_value`.
- **Cleanup:** `unknown_connection` reply deduped into a helper.

## ⚠️ Testing

`tests/test_zmq_v2_protocol.py` could **not** be run in CI / the dev container —
it depends on `zmq_v2` (parent labscript-suite repo) and the `rastering` conda
env. **Run it in the `rastering` env on the lab machine before merge.** Only
`tests/test_raster_pathmodel.py` is CI/camera-safe per CLAUDE.md.

## BLACS handoff contract

The v2 wire contract the BLACS `RasteringDevice` must match (set by the port
commits — **not changed by the polish pass**):

| Request | Reply |
|---|---|
| `move_to_next` at iterator end | `SUCCESS` + `extra.finished=True` (was non-spec v1 `"FINISHED"`). BLACS `RasteringWorker.transition_to_buffered` checks `response.get("finished") is True`. |
| `arm_raster` | `SUCCESS` + `extra.mode ∈ {"continuous","step"}` |
| `PROGRAM_VALUE` coord move | `timeout_sec` lives in the v2 `args` dict (defaults to 10s) |
| unknown connection | `status="UNKNOWN_CONNECTION"`, `error.code="unknown_connection"` |

Error codes the BLACS side may receive: `no_raster_configured`,
`raster_not_active`, `raster_in_continuous_mode`, `raster_step_failed`,
`motor_move_failed` (retryable), `invalid_value`, `unknown_connection`,
`v1_protocol_refused` (base class).

PUB-SUB topics are **unchanged**: `{laser_raster_x_coord,laser_raster_y_coord}_monitor`,
`heartbeat`, `raster_mode`, `calibration_status`, `raster_progress`.

If connection names or PUB-SUB topics ever change, the BLACS device must be
updated in lockstep (see CLAUDE.md BLACS Integration + that device's
`BLACS_Integration_Notes.md`).

https://claude.ai/code/session_01GwkfQTBju4uE7U6vUFRvvj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwkfQTBju4uE7U6vUFRvvj)_